### PR TITLE
Add spatial_extent method to Datacube to use with e.g. plt.imshow()

### DIFF
--- a/squirrel/data.py
+++ b/squirrel/data.py
@@ -322,7 +322,7 @@ class Datacube(Spectra):
         [x_left, x_right, y_bottom, y_top].
 
         ----------
-        :param pyplot: optional, If True, returns the extent as required by e.g. plt.imshow(), by default False
+        :param pyplot: optional, by default `False`. If `True`, returns the extent as required by, e.g., `plt.imshow()`.
         :type pyplot: bool
         :return: [x_left, x_right, y_bottom, y_top]
         :rtype: list

--- a/squirrel/data.py
+++ b/squirrel/data.py
@@ -321,10 +321,11 @@ class Datacube(Spectra):
         """Return the extent of the datacube along x and y directions, as a list
         [x_left, x_right, y_bottom, y_top].
 
-        Parameters
         ----------
-        pyplot : bool, optional
-            If True, returns the extent as required by e.g. plt.imshow(), by default False
+        :param pyplot: optional, If True, returns the extent as required by e.g. plt.imshow(), by default False
+        :type pyplot: bool
+        :return: [x_left, x_right, y_bottom, y_top]
+        :rtype: list
         """
         x_coord = self.x_coordinates
         y_coord = self.y_coordinates

--- a/squirrel/data.py
+++ b/squirrel/data.py
@@ -316,10 +316,9 @@ class Datacube(Spectra):
         """Return the y coordinates of the data."""
         if hasattr(self, "_y_coordinates"):
             return self._y_coordinates
-        
+
     def spatial_extent(self, pyplot=False):
-        """
-        Return the extent of the datacube along x and y directions, as a list
+        """Return the extent of the datacube along x and y directions, as a list
         [x_left, x_right, y_bottom, y_top].
 
         Parameters
@@ -337,21 +336,24 @@ class Datacube(Spectra):
             y_increasing = y_step > 0
             y_step = abs(y_step)
             extent = [
-                x_coord[0, 0], x_coord[0, -1], y_coord[0, 0], y_coord[-1, 0],
+                x_coord[0, 0],
+                x_coord[0, -1],
+                y_coord[0, 0],
+                y_coord[-1, 0],
             ]
             if pyplot is True:
                 if x_increasing:
-                    extent[0] -= x_step / 2.
-                    extent[1] += x_step / 2.
+                    extent[0] -= x_step / 2.0
+                    extent[1] += x_step / 2.0
                 else:
-                    extent[0] += x_step / 2.
-                    extent[1] -= x_step / 2.
+                    extent[0] += x_step / 2.0
+                    extent[1] -= x_step / 2.0
                 if y_increasing:
-                    extent[2] -= y_step / 2.
-                    extent[3] += y_step / 2.
+                    extent[2] -= y_step / 2.0
+                    extent[3] += y_step / 2.0
                 else:
-                    extent[2] += y_step / 2.
-                    extent[3] -= y_step / 2.
+                    extent[2] += y_step / 2.0
+                    extent[3] -= y_step / 2.0
             return extent
 
 

--- a/squirrel/data.py
+++ b/squirrel/data.py
@@ -316,6 +316,43 @@ class Datacube(Spectra):
         """Return the y coordinates of the data."""
         if hasattr(self, "_y_coordinates"):
             return self._y_coordinates
+        
+    def spatial_extent(self, pyplot=False):
+        """
+        Return the extent of the datacube along x and y directions, as a list
+        [x_left, x_right, y_bottom, y_top].
+
+        Parameters
+        ----------
+        pyplot : bool, optional
+            If True, returns the extent as required by e.g. plt.imshow(), by default False
+        """
+        x_coord = self.x_coordinates
+        y_coord = self.y_coordinates
+        if x_coord is not None:
+            x_step = x_coord[0, 1] - x_coord[0, 0]
+            x_increasing = x_step > 0
+            x_step = abs(x_step)
+            y_step = y_coord[1, 0] - y_coord[0, 0]
+            y_increasing = y_step > 0
+            y_step = abs(y_step)
+            extent = [
+                x_coord[0, 0], x_coord[0, -1], y_coord[0, 0], y_coord[-1, 0],
+            ]
+            if pyplot is True:
+                if x_increasing:
+                    extent[0] -= x_step / 2.
+                    extent[1] += x_step / 2.
+                else:
+                    extent[0] += x_step / 2.
+                    extent[1] -= x_step / 2.
+                if y_increasing:
+                    extent[2] -= y_step / 2.
+                    extent[3] += y_step / 2.
+                else:
+                    extent[2] += y_step / 2.
+                    extent[3] -= y_step / 2.
+            return extent
 
 
 class VoronoiBinnedSpectra(Spectra):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -204,7 +204,10 @@ class TestDatacube:
                 self.flux_unit,
                 self.noise,
             )
-        datacube = _get_datacube(np.array([[-0.1, 0], [0, 0.1]]))  # x-axis decreasing towards right
+
+        datacube = _get_datacube(
+            np.array([[-0.1, 0], [0, 0.1]])
+        )  # x-axis decreasing towards right
         npt.assert_array_almost_equal(
             datacube.spatial_extent(pyplot=False),
             [0.1, -0.1, -0.1, 0.1],
@@ -215,7 +218,9 @@ class TestDatacube:
             [0.15, -0.15, -0.15, 0.15],
             decimal=8,
         )
-        datacube = _get_datacube(np.array([[0.1, 0], [0, -0.1]]))  # y-axis decreasing towards up
+        datacube = _get_datacube(
+            np.array([[0.1, 0], [0, -0.1]])
+        )  # y-axis decreasing towards up
         npt.assert_array_almost_equal(
             datacube.spatial_extent(pyplot=False),
             [-0.1, 0.1, 0.1, -0.1],

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -177,6 +177,56 @@ class TestDatacube:
             [[-0.1, -0.1, -0.1], [0, 0, 0], [0.1, 0.1, 0.1]],
         )
 
+    def test_spatial_extent(self):
+        npt.assert_array_almost_equal(
+            self.datacube.spatial_extent(pyplot=False),
+            [-0.1, 0.1, -0.1, 0.1],
+            decimal=8,
+        )
+        npt.assert_array_almost_equal(
+            self.datacube.spatial_extent(pyplot=True),
+            [-0.15, 0.15, -0.15, 0.15],
+            decimal=8,
+        )
+
+        # below we test the other possible orientations of the coordinates grid
+        def _get_datacube(coordinate_transform_matrix):
+            return Datacube(
+                self.wavelengths,
+                self.flux,
+                self.wavelength_unit,
+                self.fwhm,
+                self.z_lens,
+                self.z_source,
+                self.center_pixel_x,
+                self.center_pixel_y,
+                coordinate_transform_matrix,
+                self.flux_unit,
+                self.noise,
+            )
+        datacube = _get_datacube(np.array([[-0.1, 0], [0, 0.1]]))  # x-axis decreasing towards right
+        npt.assert_array_almost_equal(
+            datacube.spatial_extent(pyplot=False),
+            [0.1, -0.1, -0.1, 0.1],
+            decimal=8,
+        )
+        npt.assert_array_almost_equal(
+            datacube.spatial_extent(pyplot=True),
+            [0.15, -0.15, -0.15, 0.15],
+            decimal=8,
+        )
+        datacube = _get_datacube(np.array([[0.1, 0], [0, -0.1]]))  # y-axis decreasing towards up
+        npt.assert_array_almost_equal(
+            datacube.spatial_extent(pyplot=False),
+            [-0.1, 0.1, 0.1, -0.1],
+            decimal=8,
+        )
+        npt.assert_array_almost_equal(
+            datacube.spatial_extent(pyplot=True),
+            [-0.15, 0.15, 0.15, -0.15],
+            decimal=8,
+        )
+
 
 class TestVoronoiBinnedSpectra:
     def setup_method(self):


### PR DESCRIPTION
Just a small method that simplifies setting up the datacube extent in plots