### PR TITLE
Add warning if template resolution is lower than spectra's

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -626,6 +626,18 @@ class TestPipeline:
             wavelength_range_extend_factor,
         )
 
+        # Test warning for larger fwhm_template than spectra.fwhm
+        with pytest.warns(UserWarning):
+            template = Pipeline.make_template_from_array(
+                fluxes,
+                wavelengths,
+                4,  # 4 > 2
+                spectra,
+                velocity_scale_ratio,
+                wavelength_factor,
+                wavelength_range_extend_factor,
+            )
+
         # Assertions to check the output
         assert isinstance(template, Template)
         assert template.wavelength_unit == "AA"


### PR DESCRIPTION
This pull request makes updates to the `squirrel/pipeline.py` file to improve spectral data processing and handle edge cases more robustly. Key changes include introducing warnings for resolution mismatches, adjusting wavelength scaling, and refining template creation logic.

### Handling resolution mismatches:

* Added a warning in `make_template_from_array` to notify users when the template resolution is lower than the spectra resolution, advising them to subtract the offset in quadrature during kinematic extraction.

### Wavelength scaling adjustments:

* Normalized wavelengths and `fwhm_template` by dividing them by `wavelength_factor` to ensure consistent scaling during processing.
* Removed the division by `wavelength_factor` when converting log wavelengths back to linear scale, simplifying the computation of `templates_wavelengths`.