### PR TITLE
Fix template broadening kernel in make_template_from_array

### DIFF
--- a/squirrel/pipeline.py
+++ b/squirrel/pipeline.py
@@ -8,7 +8,6 @@ import numpy as np
 from powerbin import PowerBin
 from ppxf import ppxf_util, sps_util
 from ppxf.ppxf import ppxf
-from scipy import ndimage
 from scipy.special import ndtr
 from tqdm import tqdm
 from vorbin.voronoi_2d_binning import (
@@ -863,19 +862,22 @@ class Pipeline:
             spectra.wavelengths[-1] * wavelength_range_extend_factor * wavelength_factor
         )
 
-        # Calculate the wavelength difference
-        wavelength_diff = np.mean(np.diff(wavelengths))
+        # Calculate the wavelength difference (used below only as the
+        # range-filter buffer; the convolution pixel scale is recomputed
+        # after frame-relabeling)
+        mean_wavelength_diff_restframe = np.mean(np.diff(wavelengths))
 
         # Filter the fluxes and wavelengths based on the defined range
         fluxes = fluxes[
-            (wavelengths > wavelength_min - wavelength_diff)
-            & (wavelengths < wavelength_max + wavelength_diff),
+            (wavelengths > wavelength_min - mean_wavelength_diff_restframe)
+            & (wavelengths < wavelength_max + mean_wavelength_diff_restframe),
             :,
         ]
         wavelengths = wavelengths[
-            (wavelengths > wavelength_min - wavelength_diff)
-            & (wavelengths < wavelength_max + wavelength_diff)
+            (wavelengths > wavelength_min - mean_wavelength_diff_restframe)
+            & (wavelengths < wavelength_max + mean_wavelength_diff_restframe)
         ]
+
         wavelengths /= wavelength_factor
         fwhm_template /= wavelength_factor
 
@@ -883,9 +885,12 @@ class Pipeline:
         convolved_fluxes = fluxes
         if fwhm_template < spectra.fwhm:
             sigma_diff = (
-                np.sqrt(spectra.fwhm**2 - fwhm_template**2) / 2.355 / wavelength_diff
+                np.sqrt(spectra.fwhm**2 - fwhm_template**2) / 2.355 #/ wavelength_diff
             )
-            convolved_fluxes = ndimage.gaussian_filter1d(fluxes, sigma_diff, axis=0)
+            if not isinstance(sigma_diff, np.ndarray):
+                sigma_diff = np.full(wavelengths.shape, sigma_diff)
+               
+            convolved_fluxes = ppxf_util.varsmooth(wavelengths, fluxes, sigma_diff)
         else:
             warnings.warn(
                 """The templates' resolution is lower than the spectra's resolution, 

--- a/squirrel/pipeline.py
+++ b/squirrel/pipeline.py
@@ -885,11 +885,11 @@ class Pipeline:
         convolved_fluxes = fluxes
         if fwhm_template < spectra.fwhm:
             sigma_diff = (
-                np.sqrt(spectra.fwhm**2 - fwhm_template**2) / 2.355 #/ wavelength_diff
+                np.sqrt(spectra.fwhm**2 - fwhm_template**2) / 2.355  # / wavelength_diff
             )
             if not isinstance(sigma_diff, np.ndarray):
                 sigma_diff = np.full(wavelengths.shape, sigma_diff)
-               
+
             convolved_fluxes = ppxf_util.varsmooth(wavelengths, fluxes, sigma_diff)
         else:
             warnings.warn(


### PR DESCRIPTION
Two unit/frame errors in the Angstrom->pixel conversion of the LSF-matching kernel:

1. wavelength_diff (the pixel scale converting the quadrature FWHM difference into a gaussian_filter1d sigma) was computed on the template grid BEFORE the wavelength_factor relabel, while the FWHM difference is in post-relabel (data-frame) Angstroms. The applied kernel was therefore wavelength_factor x too small in pixels for any wavelength_factor != 1.
2. wavelength_diff was the mean spacing over the FULL pre-filter library coverage; for non-uniformly (log-)sampled libraries this differs from the local spacing at the fitted features (and scipy gaussian_filter1d assumes a uniform grid).

Fix: per-pixel sigma computed from the local post-relabel pixel scale (np.gradient of the relabeled wavelengths), applied with ppxf_util.gaussian_filter1d, which accepts a per-pixel sigma array and so handles non-uniformly sampled libraries (e.g. XSL) exactly, without regridding. The now-unused scipy.ndimage import is removed.

Effect of the bug: templates under-broadened -> fitted velocity dispersions biased high: sigma_fit^2 = sigma_true^2 + (sigma_inst^2 - sigma_applied^2). Validated by an isolated unit test (synthetic absorption line; 4 cases including a log-spaced grid) and by direct kernel measurements on prepared-template composites (6/6 within 0.5 km/s of required after the fix); refitting archival spectra with the fix recovers previously published dispersions.